### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X main.version={{.Tag}} -X main.commit={{.Commit}}'
   goos:
     - windows
     - linux
@@ -24,9 +24,9 @@ builds:
   binary: '{{ .ProjectName }}'
 archives:
 - format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  name_template: '{{ .ProjectName }}_{{ .Tag }}_SHA256SUMS'
   algorithm: sha256
 signs:
   - artifacts: checksum


### PR DESCRIPTION
 * use .Tag as version to avoid goreleaser removing the
   v prefix
 * remove version from archive so that install instructions
   do not require the version twice in the URL