### PR TITLE
Continue to watch for changes on TF error

### DIFF
--- a/cli/local.go
+++ b/cli/local.go
@@ -17,7 +17,7 @@ type Local struct {
 func (l *Local) Apply(path string, skipWatch bool) (err error) {
 	// provision the development environment
 	err = l.Runner.Run(false)
-	if err != nil {
+	if err != nil && skipWatch {
 		return errors.New(fmt.Sprintf("provisioning local environment error: %s", err))
 	}
 
@@ -35,10 +35,7 @@ func (l *Local) Apply(path string, skipWatch bool) (err error) {
 	for {
 		log.Println("#### Watching for changes")
 		<-ev
-		err = l.Runner.Run(false)
-		if err != nil {
-			return errors.New(fmt.Sprintf("updating local environment error: %s", err))
-		}
+		l.Runner.Run(false)
 	}
 }
 

--- a/cli/local_test.go
+++ b/cli/local_test.go
@@ -53,7 +53,7 @@ func TestLocalApplyProvisionError(t *testing.T) {
 
 	local := Local{Runner: mtc}
 	p := filepath.Join(fixturesPath, "multi-cloud")
-	err := local.Apply(p, false)
+	err := local.Apply(p, true)
 
 	assert.Equal(t, false, mtc.destroy, nil)
 	assert.Error(t, err, nil)


### PR DESCRIPTION
Previously, kbst local apply, would stop watching on any error. This
made for a tedious user experience, requiring to restart the watch
every time there was an error in the Terraform.

Instead, we now print the error, and wait for another change to rerun.