### PR TITLE
fix

### DIFF
--- a/pkg/runner/terraform.go
+++ b/pkg/runner/terraform.go
@@ -63,6 +63,7 @@ func (ltc *localTerraformContainer) Run(destroy bool) (err error) {
 	ltc.destroy = destroy
 	buildCmd := ltc.buildCmd()
 	err = buildCmd.Run()
+	fmt.Errorf("234324docker run error: %s", err)
 	if err != nil {
 		return fmt.Errorf("docker build error: %s", err)
 	}
@@ -81,6 +82,7 @@ func (ltc *localTerraformContainer) Run(destroy bool) (err error) {
 			// https://github.com/docker/for-mac/issues/4755
 			// if the first preflight fails, we try the raw socket
 			ltc.socketVolume = "/var/run/docker.sock.raw:/var/run/docker.sock"
+			preflightCmd := ltc.preflightCmd()
 			err = preflightCmd.Run()
 			if err != nil {
 				log.Fatalf("docker preflight error:\r\n%s", b)

--- a/pkg/runner/terraform.go
+++ b/pkg/runner/terraform.go
@@ -63,7 +63,6 @@ func (ltc *localTerraformContainer) Run(destroy bool) (err error) {
 	ltc.destroy = destroy
 	buildCmd := ltc.buildCmd()
 	err = buildCmd.Run()
-	fmt.Errorf("234324docker run error: %s", err)
 	if err != nil {
 		return fmt.Errorf("docker build error: %s", err)
 	}


### PR DESCRIPTION
Current code to not reflect the changes for ltc.socketVolume.

```
kbst local apply
[+] Building 0.8s (9/9) FINISHED                                                                                                                                                                                                                                                                                                                                       
 => [internal] load build definition from Dockerfile.loc                                                                                                                                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 41B                                                                                                                                                                                                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/kubestack/framework:v0.12.2-beta.0-kind                                                                                                                                                                                                                                                                                0.7s
 => [1/4] FROM docker.io/kubestack/framework:v0.12.2-beta.0-kind@sha256:932f9fd14dc96329743e20054881d336ac4397573096b70ea3147f329f7120eb                                                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring context: 1.36kB                                                                                                                                                                                                                                                                                                                               0.0s
 => CACHED [2/4] RUN mkdir -p /infra/terraform.tfstate.d &&    chown 501:20 -R /infra                                                                                                                                                                                                                                                                             0.0s
 => CACHED [3/4] COPY manifests /infra/manifests                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [4/4] COPY *.tf *.tfvars /infra/                                                                                                                                                                                                                                                                                                                       0.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                                            0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                           0.0s
 => => writing image sha256:31702f73ceff72f6a0ee70635db79f5306b217adfc07d207ef3c0bcf0e000126                                                                                                                                                                                                                                                                      0.0s
 => => naming to docker.io/library/kbst:2189528-loc                                                                                                                                                                                                                                                                                                               0.0s
2021/03/09 17:07:21 docker preflight error:
errors pretty printing info
Client:
 Context:    default
 Debug Mode: false

Server:
ERROR: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.24/info: dial unix /var/run/docker.sock: connect: permission denied
```